### PR TITLE
Add verdaccio as a open source registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ A website dedicated to alternatives to npmjs.com
 - npm-register: [on npm](https://www.npmjs.com/package/npm-register) / [on Github](https://github.com/dickeyxxx/npm-register)
 - registry-mirror: [on npm](https://www.npmjs.com/package/registry-mirror) / [on GitHub](https://github.com/diasdavid/registry-mirror)
 - ipfs-npm (successor to registry-mirror): [on npm](https://www.npmjs.com/package/ipfs-npm) / [on Github](https://github.com/diasdavid/npm-on-ipfs)
+- verdaccio: [on npm](https://www.npmjs.com/package/verdaccio) / [on Github](https://github.com/verdaccio/verdaccio)
 - Know more? Fork this file to add it to this list and send me a pull request!
 
 ## How to use alternative registries


### PR DESCRIPTION
Verdaccio is a fork of sinopia. Since sinopia is not being maintained and [Verdaccio](https://verdaccio.org/) is the most affordable option for old sinopia users.